### PR TITLE
fix: replace GREATEST_MAIN_BEGIN/END to avoid _BEGIN/_END marker conflicts

### DIFF
--- a/modules/10-basics/10-hello-world/test.c
+++ b/modules/10-basics/10-hello-world/test.c
@@ -25,7 +25,9 @@ TEST test_base(void) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TEST(test_base);
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/modules/10-basics/20-variables/test.c
+++ b/modules/10-basics/20-variables/test.c
@@ -43,7 +43,9 @@ TEST test_base(void) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TEST(test_base);
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/modules/10-basics/30-floats/test.c
+++ b/modules/10-basics/30-floats/test.c
@@ -43,7 +43,9 @@ TEST test_base(void) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TEST(test_base);
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/modules/10-basics/40-for/test.c
+++ b/modules/10-basics/40-for/test.c
@@ -43,7 +43,9 @@ TEST test_base(void) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TEST(test_base);
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/modules/10-basics/50-functions/test.c
+++ b/modules/10-basics/50-functions/test.c
@@ -12,7 +12,9 @@ TEST test_base(void) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TEST(test_base);
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/modules/10-basics/60-if-else/test.c
+++ b/modules/10-basics/60-if-else/test.c
@@ -25,7 +25,8 @@ TEST test_base(int limit, char *expected) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TESTp(
         test_base,
         5,
@@ -41,5 +42,6 @@ int main(int argc, char **argv) {
         20,
         "1 2 Fizz 4 Buzz Fizz 7 8 Fizz Buzz 11 Fizz 13 14 FizzBuzz 16 17 Fizz 19 Buzz"
     );
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/modules/10-basics/70-switch/test.c
+++ b/modules/10-basics/70-switch/test.c
@@ -25,12 +25,14 @@ TEST test_base(int number, char *expected) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TESTp(test_base, 0, "Zero");
     RUN_TESTp(test_base, 1, "One");
     RUN_TESTp(test_base, 2, "Two");
     RUN_TESTp(test_base, 3, "Three");
     RUN_TESTp(test_base, 4, "4");
     RUN_TESTp(test_base, 9, "9");
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/modules/10-basics/80-array/test.c
+++ b/modules/10-basics/80-array/test.c
@@ -15,7 +15,9 @@ TEST test_base(void) {
 GREATEST_MAIN_DEFS();
 
 int main(int argc, char **argv) {
-    GREATEST_MAIN_BEGIN();
+    GREATEST_INIT();
+    greatest_parse_options(argc, argv);
     RUN_TEST(test_base);
-    GREATEST_MAIN_END();
+    GREATEST_PRINT_REPORT();
+    return (greatest_all_passed() ? EXIT_SUCCESS : EXIT_FAILURE);
 }


### PR DESCRIPTION
## Summary

- `GREATEST_MAIN_BEGIN()` and `GREATEST_MAIN_END()` macros contain `_BEGIN`/`_END` substrings that the platform treats as student code markers
- This caused `RUN_TEST()` between them to be replaced with a \"write your solution here\" placeholder, breaking all tests
- Fixed by inlining the macro expansions: `GREATEST_INIT()` + `greatest_parse_options()` and `GREATEST_PRINT_REPORT()` + `greatest_all_passed()`

Affects all 8 exercises in `modules/10-basics/`.

Related: https://tracker.yandex.ru/FEEDBACK-285

🤖 Generated with [Claude Code](https://claude.com/claude-code)